### PR TITLE
Revert "fpc: keep fpc in system-background"

### DIFF
--- a/biometrics/fingerprint/2.1/default/android.hardware.biometrics.fingerprint@2.1-service.rc
+++ b/biometrics/fingerprint/2.1/default/android.hardware.biometrics.fingerprint@2.1-service.rc
@@ -5,4 +5,3 @@ service vendor.fps_hal /vendor/bin/hw/android.hardware.biometrics.fingerprint@2.
     class late_start
     user system
     group system input uhid
-    writepid /dev/cpuset/system-background/tasks


### PR DESCRIPTION
While Google found that fingerprint HAL is insensitive to
increased CPU throughput, we have not found that to be the
case. Allowing more CPUs makes fingerprint unlock up to
2x faster in some tests.

SM8250 device with fingerprint on display:
- Before: 3128ms
- After: 944ms

SDM845 device with fingerprint on the power button:
- Before: 1146ms
- After: 688ms

This reverts commit d0fdb4431d26e4f257b8867f67ffd9b4a9818d9e.

Change-Id: I7a28d82caee2b8503b974a8226b29240eb072ceb