### PR TITLE
wifi: optionally reset the interface after setMacAddress

### DIFF
--- a/wifi/1.4/default/Android.mk
+++ b/wifi/1.4/default/Android.mk
@@ -39,6 +39,9 @@ endif
 ifdef WIFI_AVOID_IFACE_RESET_MAC_CHANGE
 LOCAL_CPPFLAGS += -DWIFI_AVOID_IFACE_RESET_MAC_CHANGE
 endif
+ifdef WIFI_RESET_IFACE_AFTER_MAC_CHANGE
+LOCAL_CPPFLAGS += -DWIFI_RESET_IFACE_AFTER_MAC_CHANGE
+endif
 # Allow implicit fallthroughs in wifi_legacy_hal.cpp until they are fixed.
 LOCAL_CFLAGS += -Wno-error=implicit-fallthrough
 LOCAL_SRC_FILES := \

--- a/wifi/1.4/default/wifi_iface_util.cpp
+++ b/wifi/1.4/default/wifi_iface_util.cpp
@@ -53,7 +53,7 @@ std::array<uint8_t, 6> WifiIfaceUtil::getFactoryMacAddress(
 
 bool WifiIfaceUtil::setMacAddress(const std::string& iface_name,
                                   const std::array<uint8_t, 6>& mac) {
-#ifndef WIFI_AVOID_IFACE_RESET_MAC_CHANGE
+#if !defined(WIFI_AVOID_IFACE_RESET_MAC_CHANGE) && !defined(WIFI_RESET_IFACE_AFTER_MAC_CHANGE)
     if (!iface_tool_.lock()->SetUpState(iface_name.c_str(), false)) {
         LOG(ERROR) << "SetUpState(false) failed.";
         return false;
@@ -63,6 +63,12 @@ bool WifiIfaceUtil::setMacAddress(const std::string& iface_name,
         LOG(ERROR) << "SetMacAddress failed.";
         return false;
     }
+#ifdef WIFI_RESET_IFACE_AFTER_MAC_CHANGE
+    if (!iface_tool_.lock()->SetUpState(iface_name.c_str(), false)) {
+        LOG(ERROR) << "SetUpState(false) failed.";
+        return false;
+    }
+#endif
 #ifndef WIFI_AVOID_IFACE_RESET_MAC_CHANGE
     if (!iface_tool_.lock()->SetUpState(iface_name.c_str(), true)) {
         LOG(ERROR) << "SetUpState(true) failed.";


### PR DESCRIPTION
* Some wifi chips need this to properly work with mac randomization
  like samsung devices using bcmdhd
* Without this they're just stuck at "Authenticating"
  and eventually disconnect

Change-Id: I11ea0218c96bb8621597548c52463b7f2fd593d6